### PR TITLE
add events for dimension-import and instance-complete

### DIFF
--- a/events/cantabuar_dataset_category_dimension_import.go
+++ b/events/cantabuar_dataset_category_dimension_import.go
@@ -1,0 +1,29 @@
+package events
+
+import "github.com/ONSdigital/dp-kafka/v2/avro"
+
+// CantabularDatasetCategoryDimensionImport is an event produced to trigger
+// the import of dimension options for a given dimension from Cantabular
+type CantabularDatasetCategoryDimensionImport struct {
+	JobID          string `avro:"job_id"`
+	InstanceID     string `avro:"instance_id"`
+	DimensionID    string `avro:"dimension_id"`
+	CantabularBlob string `avro:"cantabular_blob"`
+}
+
+var cantabularDatasetCategoryDimensionImportSchema = `{
+  "type": "record",
+  "name": "cantabular-dataset-category-dimension-import",
+  "fields": [
+    {"name": "dimension_id",   "type": "string"},
+    {"name": "job_id", "type": "string"},
+    {"name": "instance_id", "type": "string"},
+    {"name": "cantabular_blob", "type": "string"}
+  ]
+}`
+
+// CantabularDatasetCategoryDimensionImportSchema is the avro schema for the
+// CantabularDatasetCategoryDimensionImport event
+var CantabularDatasetCategoryDimensionImportSchema = &avro.Schema{
+	Definition: cantabularDatasetCategoryDimensionImportSchema,
+}

--- a/events/cantabular_dataset_instance_complete.go
+++ b/events/cantabular_dataset_instance_complete.go
@@ -1,0 +1,26 @@
+package events
+
+import "github.com/ONSdigital/dp-kafka/v2/avro"
+
+// CantabularDatasetInstanceComplete is the event produced when the
+// dimension options have been imported and the instance has successfully
+// been imported from Cantabular
+type CantabularDatasetInstanceComplete struct {
+	InstanceID    string `avro:"instance_id"`
+	CantabularBob string `avro:"cantabular_blob"`
+}
+
+var cantabularDatasetInstanceCompleteSchema = `{
+  "type": "record",
+  "name": "cantabular-dataset-instance-complete",
+  "fields": [
+    {"name": "instance_id",     "type": "string"},
+    {"name": "cantabular_blob", "type": "string"}
+  ]
+}`
+
+// CantabularDatasetInstanceCompleteSchema is the avro schema for the
+// CantabularDatasetInstanceComplete event
+var CantabularDatasetInstanceCompleteSchema = &avro.Schema{
+	Definition: cantabularDatasetInstanceCompleteSchema,
+}

--- a/events/cantabular_dataset_instance_started.go
+++ b/events/cantabular_dataset_instance_started.go
@@ -2,7 +2,8 @@ package events
 
 import "github.com/ONSdigital/dp-kafka/v2/avro"
 
-// CantabularDatasetInstanceStarted is an event produced when a cantabular import is triggered
+// CantabularDatasetInstanceStarted is an event produced when a cantabular
+// import is triggered
 type CantabularDatasetInstanceStarted struct {
 	RecipeID       string `avro:"recipe_id"`
 	InstanceID     string `avro:"instance_id"`
@@ -21,7 +22,8 @@ var cantabularDatasetInstanceStartedSchema = `{
   ]
 }`
 
-// CantabularDatasetInstanceStartedSchema provides an Avro schema for the CantabularDatasetInstanceStarted event
+// CantabularDatasetInstanceStartedSchema provides an Avro schema for the
+// CantabularDatasetInstanceStarted event
 var CantabularDatasetInstanceStartedSchema = &avro.Schema{
 	Definition: cantabularDatasetInstanceStartedSchema,
 }


### PR DESCRIPTION
### What

Added remaining events for the Cantabular import journey. 

Up until now they have resided in the services that use them being defined in multiple places while they were being finalised.

Now we have a good idea of what they they need to be they can be extracted to this centralised repository to be used across the board as is done elsewhere.

### How to review

Check code makes sense, events are the same as found in `dp-import-cantabular-dimension-options` (and `dp-import-cantabular-dataset` and `dp-cantabular-csv-exporter`)

### Who can review

Anyone
